### PR TITLE
Automate package version with setuptools_scm

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ pip install "neural_importance[tensorflow]"  # for Keras
 pip install "neural_importance[torch]"       # for PyTorch
 ```
 
+The package uses `setuptools_scm` to derive its version from Git tags. Access it
+via:
+
+```python
+from neural_importance import __version__
+print(__version__)
+```
+
 ```python
 from neural_importance import VarianceImportanceCallback, AccuracyMonitor
 

--- a/neural_importance/__init__.py
+++ b/neural_importance/__init__.py
@@ -1,11 +1,18 @@
 """Utilities for variance-based feature importance in neural networks."""
 
+from importlib import metadata
+
 from .callbacks import (
     VarianceImportanceBase,
     VarianceImportanceKeras,
     VarianceImportanceTorch,
 )
 from .utils import MetricThreshold
+
+try:
+    __version__ = metadata.version("neural-feature-importance")
+except metadata.PackageNotFoundError:  # pragma: no cover - package not installed
+    __version__ = "0.0.dev0"
 
 __all__ = [
     "VarianceImportanceBase",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,15 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "neural-feature-importance"
-version = "0.1.0"
 description = "Variance-based feature importance for Neural Networks using callbacks for Keras and PyTorch"
 authors = [{name = "CR de Sá"}]
 dependencies = ["numpy"]
+dynamic = ["version"]
 
 [project.optional-dependencies]
 tensorflow = ["tensorflow"]
 torch = ["torch"]
+[tool.setuptools_scm]


### PR DESCRIPTION
## Summary
- enable setuptools_scm in `pyproject.toml`
- expose `__version__` from package metadata
- document dynamic versioning in README

## Testing
- `python -m py_compile neural_importance/callbacks.py`
- `python -m py_compile "variance-based feature importance in artificial neural networks.ipynb" 2>&1 | head`
- `jupyter nbconvert --to script "variance-based feature importance in artificial neural networks.ipynb" --stdout | head`

------
https://chatgpt.com/codex/tasks/task_e_6858e578489c8329ba3dc84d1e6d9edd