### PR TITLE
Update README to reflect new callback names

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,15 @@ print(__version__)
 ```
 
 ```python
-from neural_feature_importance import VarianceImportanceCallback, AccuracyMonitor
+from neural_feature_importance import VarianceImportanceKeras
+from neural_feature_importance.utils import MetricThreshold
 
 import logging
 
 logging.basicConfig(level=logging.INFO)
 
-VIANN = VarianceImportanceCallback()
-monitor = AccuracyMonitor(baseline=0.95)
+VIANN = VarianceImportanceKeras()
+monitor = MetricThreshold(monitor="val_accuracy", threshold=0.95)
 ```
 
 For a PyTorch model, use ``VarianceImportanceTorch`` and call its
@@ -88,7 +89,7 @@ with those from a `RandomForestClassifier`.
 python compare_feature_importance.py
 ```
 
-For a larger experiment across several datasets, run `full_experiment.py`. The script builds a simple network for each dataset, applies the `AccuracyMonitor` for early stopping, and prints the correlation between neural network importances and a random forest baseline.
+For a larger experiment across several datasets, run `full_experiment.py`. The script builds a simple network for each dataset, applies the `MetricThreshold` callback for early stopping, and prints the correlation between neural network importances and a random forest baseline.
 
 ```bash
 python full_experiment.py

--- a/README.md
+++ b/README.md
@@ -2,29 +2,33 @@
 
 Variance-based feature importance for deep learning models.
 
-`neural-feature-importance` implements the method described in [CR de Sá, *Variance-based Feature Importance in Neural Networks*](https://doi.org/10.1007/978-3-030-33778-0_24). The library tracks the variance of input weights during training using Welford's algorithm and computes normalized importance scores.
+`neural-feature-importance` implements the method described in
+[CR de Sá, *Variance-based Feature Importance in Neural Networks*](https://doi.org/10.1007/978-3-030-33778-0_24).
+It tracks the variance of the first trainable layer using Welford's algorithm
+and produces normalized importance scores for each feature.
 
 ## Features
-- `VarianceImportanceKeras` callback for TensorFlow/Keras
-- `VarianceImportanceTorch` helper for PyTorch
-- Early-stopping `MetricThreshold` callback
-- Utility scripts to reproduce the experiments from the paper
+
+- `VarianceImportanceKeras` — drop-in callback for TensorFlow/Keras models
+- `VarianceImportanceTorch` — helper class for PyTorch training loops
+- `MetricThreshold` — early-stopping callback based on a monitored metric
+- Example scripts to reproduce the experiments from the paper
 
 ## Installation
 
 ```bash
-pip install "neural-feature-importance[tensorflow]"  # Keras support
-pip install "neural-feature-importance[torch]"       # PyTorch support
+pip install "neural-feature-importance[tensorflow]"  # for Keras
+pip install "neural-feature-importance[torch]"       # for PyTorch
 ```
 
-## Getting the version
+Retrieve the package version via:
 
 ```python
 from neural_feature_importance import __version__
 print(__version__)
 ```
 
-## Usage
+## Quick start
 
 ### Keras
 
@@ -34,8 +38,8 @@ from neural_feature_importance.utils import MetricThreshold
 
 viann = VarianceImportanceKeras()
 monitor = MetricThreshold(monitor="val_accuracy", threshold=0.95)
-model.fit(X, Y, validation_split=0.05, epochs=30, callbacks=[viann, monitor])
-print(viann.var_scores)
+model.fit(X, y, validation_split=0.05, epochs=30, callbacks=[viann, monitor])
+print(viann.feature_importances_)
 ```
 
 ### PyTorch
@@ -46,21 +50,22 @@ from neural_feature_importance import VarianceImportanceTorch
 tracker = VarianceImportanceTorch(model)
 tracker.on_train_begin()
 for epoch in range(num_epochs):
-    train_one_epoch(model, optimizer, data_loader)
+    train_one_epoch(model, optimizer, dataloader)
     tracker.on_epoch_end()
 tracker.on_train_end()
-print(tracker.var_scores)
+print(tracker.feature_importances_)
 ```
 
 ## Example scripts
 
-Run `compare_feature_importance.py` to train a small network on the Iris dataset and compare the scores with a random forest baseline:
+Run `compare_feature_importance.py` to train a small network on the Iris dataset
+and compare the scores with a random forest baseline:
 
 ```bash
 python compare_feature_importance.py
 ```
 
-Run `full_experiment.py` to reproduce the paper's experiment across several datasets:
+Run `full_experiment.py` to reproduce the experiments from the paper:
 
 ```bash
 python full_experiment.py
@@ -68,7 +73,7 @@ python full_experiment.py
 
 ## Development
 
-After making changes, run:
+After making changes, run the following checks:
 
 ```bash
 python -m py_compile neural_feature_importance/callbacks.py

--- a/README.md
+++ b/README.md
@@ -1,55 +1,44 @@
-# Variance-based Feature Importance in Neural Networks / Deep Learning
+# neural-feature-importance
 
-This file provides a working example of how to measure the importance of features (inputs) in neural networks. 
+Variance-based feature importance for deep learning models.
 
-This method is a new method to measure the relative importance of features in Artificial Neural Networks (ANN) models. Its underlying principle assumes that the more important a feature is, the more the weights, connected to the respective input neuron, will change during the training of the model. To capture this behavior, a running variance of every weight connected to the input layer is measured during training. For that, an adaptation of Welford's online algorithm for computing the online variance is proposed.
+`neural-feature-importance` implements the method described in [CR de Sá, *Variance-based Feature Importance in Neural Networks*](https://doi.org/10.1007/978-3-030-33778-0_24). The library tracks the variance of input weights during training using Welford's algorithm and computes normalized importance scores.
 
-When the training is finished, for each input, the variances of the weights are combined with the final weights to obtain the measure of relative importance for each feature.
+## Features
+- `VarianceImportanceKeras` callback for TensorFlow/Keras
+- `VarianceImportanceTorch` helper for PyTorch
+- Early-stopping `MetricThreshold` callback
+- Utility scripts to reproduce the experiments from the paper
 
-The file **variance-based feature importance in artificial neural networks.ipynb** includes the code to fully replicate the results obtained in the paper:
-
-CR de Sá [**Variance-based Feature Importance in Neural Networks**](https://doi.org/10.1007/978-3-030-33778-0_24)  
-22st International Conference on Discovery Science (DS 2019) Split, Croatia, October 28-30, 2019
-
-
-## VIANN
-#### Variance-based Feature Importance of Artificial Neural Networks
-
-This repository exposes the feature importance callback as a small Python package named `neural-feature-importance`.
-It will automatically track the first layer that contains trainable weights so you can use it with models that start with an `InputLayer` or other preprocessing layers.
-There is also a helper for PyTorch models that follows the same API.
-
-Install with pip and select the extras that match your framework:
+## Installation
 
 ```bash
-pip install "neural-feature-importance[tensorflow]"  # for Keras
-pip install "neural-feature-importance[torch]"       # for PyTorch
+pip install "neural-feature-importance[tensorflow]"  # Keras support
+pip install "neural-feature-importance[torch]"       # PyTorch support
 ```
 
-The package uses `setuptools_scm` to derive its version from Git tags. Access it
-via:
+## Getting the version
 
 ```python
 from neural_feature_importance import __version__
-
 print(__version__)
 ```
+
+## Usage
+
+### Keras
 
 ```python
 from neural_feature_importance import VarianceImportanceKeras
 from neural_feature_importance.utils import MetricThreshold
 
-import logging
-
-logging.basicConfig(level=logging.INFO)
-
-VIANN = VarianceImportanceKeras()
+viann = VarianceImportanceKeras()
 monitor = MetricThreshold(monitor="val_accuracy", threshold=0.95)
+model.fit(X, Y, validation_split=0.05, epochs=30, callbacks=[viann, monitor])
+print(viann.var_scores)
 ```
 
-For a PyTorch model, use ``VarianceImportanceTorch`` and call its
-``on_train_begin``, ``on_epoch_end`` and ``on_train_end`` methods inside your
-training loop:
+### PyTorch
 
 ```python
 from neural_feature_importance import VarianceImportanceTorch
@@ -63,34 +52,26 @@ tracker.on_train_end()
 print(tracker.var_scores)
 ```
 
-Use this callback during model training:
+## Example scripts
 
-```python
-model = Sequential()
-model.add(Dense(50, input_dim=input_dim, activation='relu', kernel_initializer='normal', kernel_regularizer=l2(0.01)))
-model.add(Dense(100, activation='relu', kernel_initializer='normal', kernel_regularizer=l2(0.01)))
-model.add(Dense(50, activation='relu', kernel_initializer='normal', kernel_regularizer=l2(0.01)))
-model.add(Dense(5, activation='softmax', kernel_initializer='normal'))
-
-model.compile(loss='categorical_crossentropy', optimizer='sgd', metrics=['accuracy'])
-model.fit(X, Y, validation_split=0.05, epochs=30, batch_size=64, shuffle=True,
-          verbose=1, callbacks=[VIANN, monitor])
-
-print(VIANN.var_scores)
-```
-
-## Comparing with Random Forest
-
-To verify the variance-based scores, run `compare_feature_importance.py`. The
-script trains a small neural network on the Iris dataset and compares the scores
-with those from a `RandomForestClassifier`.
+Run `compare_feature_importance.py` to train a small network on the Iris dataset and compare the scores with a random forest baseline:
 
 ```bash
 python compare_feature_importance.py
 ```
 
-For a larger experiment across several datasets, run `full_experiment.py`. The script builds a simple network for each dataset, applies the `MetricThreshold` callback for early stopping, and prints the correlation between neural network importances and a random forest baseline.
+Run `full_experiment.py` to reproduce the paper's experiment across several datasets:
 
 ```bash
 python full_experiment.py
+```
+
+## Development
+
+After making changes, run:
+
+```bash
+python -m py_compile neural_feature_importance/callbacks.py
+python -m py_compile "variance-based feature importance in artificial neural networks.ipynb" 2>&1 | head
+jupyter nbconvert --to script "variance-based feature importance in artificial neural networks.ipynb" --stdout | head
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # neural-feature-importance
 
+[![PyPI version](https://img.shields.io/pypi/v/neural-feature-importance.svg)](https://pypi.org/project/neural-feature-importance/)
+[![Python versions](https://img.shields.io/pypi/pyversions/neural-feature-importance.svg)](https://pypi.org/project/neural-feature-importance/)
+
 Variance-based feature importance for deep learning models.
 
 `neural-feature-importance` implements the method described in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "neural-feature-importance"
 description = "Variance-based feature importance for Neural Networks using callbacks for Keras and PyTorch"
 authors = [{name = "CR de Sá"}]
+readme = "README.md"
 dependencies = ["numpy"]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Summary
- update README imports to use `VarianceImportanceKeras`
- update early stopping example to use `MetricThreshold`
- mention `MetricThreshold` in experiment instructions

## Testing
- `python -m py_compile neural_feature_importance/callbacks.py`
- `python -m py_compile "variance-based feature importance in artificial neural networks.ipynb" 2>&1 | head`
- `jupyter nbconvert --to script "variance-based feature importance in artificial neural networks.ipynb" --stdout | head` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858f0769fe88329a02ecc7a3376a1e9