### PR TITLE
Add convolutional callbacks and example script

### DIFF
--- a/conv_visualization_example.py
+++ b/conv_visualization_example.py
@@ -1,0 +1,60 @@
+"""Example of variance-based importance with a Conv2D model."""
+
+from __future__ import annotations
+
+import logging
+
+import matplotlib.pyplot as plt
+from tensorflow.keras.datasets import mnist
+from tensorflow.keras.layers import Conv2D, Dense, Flatten, MaxPooling2D
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.utils import to_categorical
+
+from neural_feature_importance.conv_callbacks import ConvVarianceImportanceKeras
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def build_model() -> Sequential:
+    """Return a minimal Conv2D model."""
+    model = Sequential(
+        [
+            Conv2D(8, (3, 3), activation="relu", input_shape=(28, 28, 1)),
+            MaxPooling2D((2, 2)),
+            Flatten(),
+            Dense(10, activation="softmax"),
+        ]
+    )
+    model.compile(
+        optimizer="adam", loss="categorical_crossentropy", metrics=["accuracy"]
+    )
+    return model
+
+
+def main() -> None:
+    """Train model on MNIST and display a heatmap of importances."""
+    (x_train, y_train), _ = mnist.load_data()
+    x_train = x_train.astype("float32") / 255.0
+    x_train = x_train[..., None]
+    y_train = to_categorical(y_train, 10)
+
+    model = build_model()
+    callback = ConvVarianceImportanceKeras()
+    model.fit(x_train, y_train, epochs=2, batch_size=128, callbacks=[callback], verbose=0)
+
+    scores = callback.feature_importances_
+    if scores is None:
+        logger.warning("No importance scores computed.")
+        return
+
+    weights = model.layers[0].get_weights()[0]
+    heatmap = scores.reshape(weights.shape[0], weights.shape[1], weights.shape[2]).mean(axis=-1)
+    plt.imshow(heatmap, cmap="hot")
+    plt.colorbar()
+    plt.title("Feature importance heatmap")
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/neural_feature_importance/conv_callbacks.py
+++ b/neural_feature_importance/conv_callbacks.py
@@ -1,0 +1,78 @@
+"""Callbacks with convolutional layer support."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import numpy as np
+
+from .callbacks import VarianceImportanceKeras, VarianceImportanceTorch
+
+logger = logging.getLogger(__name__)
+
+
+def _flatten_weights(weights: np.ndarray, outputs_last: bool) -> np.ndarray:
+    """Return a 2-D array with shape (features, outputs)."""
+    if weights.ndim > 2:
+        if outputs_last:
+            return weights.reshape(-1, weights.shape[-1])
+        return weights.reshape(weights.shape[0], -1).T
+    return weights
+
+
+class ConvVarianceImportanceKeras(VarianceImportanceKeras):
+    """Keras callback supporting convolutional layers."""
+
+    def on_train_begin(self, logs: Optional[dict] = None) -> None:
+        self._layer = None
+        for layer in self.model.layers:
+            if layer.get_weights():
+                self._layer = layer
+                break
+        if self._layer is None:
+            raise ValueError("Model does not contain trainable weights.")
+        weights = self._layer.get_weights()[0]
+        weights = _flatten_weights(weights, outputs_last=True)
+        logger.info(
+            "Tracking variance for layer '%s' with %d features",
+            self._layer.name,
+            weights.shape[0],
+        )
+        self.start(weights)
+
+    def on_epoch_end(self, epoch: int, logs: Optional[dict] = None) -> None:
+        if self._layer is None:
+            return
+        weights = self._layer.get_weights()[0]
+        weights = _flatten_weights(weights, outputs_last=True)
+        self.update(weights)
+
+
+class ConvVarianceImportanceTorch(VarianceImportanceTorch):
+    """PyTorch helper supporting convolutional layers."""
+
+    def on_train_begin(self) -> None:
+        from torch import nn
+
+        for name, param in self.model.named_parameters():
+            if param.requires_grad and param.dim() >= 2:
+                self._param = param
+                weights = param.detach().cpu().numpy()
+                weights = _flatten_weights(weights, outputs_last=False)
+                logger.info(
+                    "Tracking variance for parameter '%s' with %d features",
+                    name,
+                    weights.shape[0],
+                )
+                self.start(weights)
+                break
+        if self._param is None:
+            raise ValueError("Model does not contain trainable parameters")
+
+    def on_epoch_end(self) -> None:
+        if self._param is None:
+            return
+        weights = self._param.detach().cpu().numpy()
+        weights = _flatten_weights(weights, outputs_last=False)
+        self.update(weights)

--- a/text_classification_example.py
+++ b/text_classification_example.py
@@ -1,0 +1,66 @@
+"""Example of variance-based importance with text classification."""
+
+from __future__ import annotations
+
+import logging
+from typing import Tuple
+
+import matplotlib.pyplot as plt
+from tensorflow.keras.datasets import imdb
+from tensorflow.keras.layers import Conv1D, Dense, Embedding, GlobalMaxPooling1D
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.preprocessing.sequence import pad_sequences
+
+from neural_feature_importance.conv_callbacks import ConvVarianceImportanceKeras
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+MAX_FEATURES = 5000
+MAX_LEN = 400
+
+
+def load_data() -> Tuple[tuple, tuple]:
+    """Return padded IMDB data."""
+    (x_train, y_train), _ = imdb.load_data(num_words=MAX_FEATURES)
+    x_train = pad_sequences(x_train, maxlen=MAX_LEN)
+    return (x_train, y_train), _
+
+
+def build_model() -> Sequential:
+    """Return a small Conv1D model."""
+    model = Sequential(
+        [
+            Embedding(MAX_FEATURES, 32, input_length=MAX_LEN, trainable=False),
+            Conv1D(16, 5, activation="relu"),
+            GlobalMaxPooling1D(),
+            Dense(1, activation="sigmoid"),
+        ]
+    )
+    model.compile(optimizer="adam", loss="binary_crossentropy", metrics=["accuracy"])
+    return model
+
+
+def main() -> None:
+    """Train the model and plot a heatmap of importances."""
+    (x_train, y_train), _ = load_data()
+    model = build_model()
+    callback = ConvVarianceImportanceKeras()
+    model.fit(x_train, y_train, epochs=2, batch_size=128, callbacks=[callback], verbose=0)
+
+    scores = callback.feature_importances_
+    if scores is None:
+        logger.warning("No importance scores computed.")
+        return
+
+    weights = model.layers[1].get_weights()[0]
+    heatmap = scores.reshape(weights.shape[0], weights.shape[1])
+    plt.imshow(heatmap, aspect="auto", cmap="hot")
+    plt.colorbar()
+    plt.title("Conv1D feature importance")
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `conv_callbacks` module with subclasses supporting convolutional layers
- add an example script training a Conv2D model on MNIST and visualising the importance heatmap

## Testing
- `python -m py_compile neural_feature_importance/callbacks.py`
- `python -m py_compile neural_feature_importance/conv_callbacks.py`
- `python -m py_compile conv_visualization_example.py`
- `python -m py_compile "variance-based feature importance in artificial neural networks.ipynb" 2>&1 | head`
- `jupyter nbconvert --to script "variance-based feature importance in artificial neural networks.ipynb" --stdout | head` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685971ff0cd4832992f0baad4c478aa9